### PR TITLE
Use fully qualified URL to avoid broken link on developer.fastly.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ For more information on how Optimizely Full Stack SDKs bucket visitors, see [her
 
 ### Contributing
 
-Please see [CONTRIBUTING](CONTRIBUTING.md).
+Please see [CONTRIBUTING](https://github.com/optimizely/fastly-compute-starter-kit/blob/main/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You will need to complete the following prerequisites to use this template:
     ```
 ## Contributing
 
-Please see [CONTRIBUTING](CONTRIBUTING.md).
+Please see [CONTRIBUTING](https://github.com/optimizely/fastly-compute-starter-kit/blob/main/CONTRIBUTING.md).
 
 ## Additional resources
 - [Fastly - Compute@Edge official documentation](https://docs.fastly.com/products/compute-at-edge)

--- a/fastly.toml
+++ b/fastly.toml
@@ -5,7 +5,7 @@ authors = ["zeeshan.ashraf@optimizely.com"]
 description = "A basic starter kit for Fastly's Compute@Edge with Optimizely built in."
 language = "javascript"
 manifest_version = 2
-name = "Optimizely"
+name = "Optimizely Full Stack"
 
 [setup.backends]
   

--- a/fastly.toml
+++ b/fastly.toml
@@ -5,7 +5,7 @@ authors = ["zeeshan.ashraf@optimizely.com"]
 description = "A basic starter kit for Fastly's Compute@Edge with Optimizely built in."
 language = "javascript"
 manifest_version = 2
-name = "optimizely"
+name = "Optimizely"
 
 [setup.backends]
   


### PR DESCRIPTION
Hi there!

On the Fastly developer hub we are displaying the contents of this repo's README:
https://developer.fastly.com/solutions/starters/optimizely-fastly-compute-starter-kit/

This PR helps us do a tiny bit of weeding:

* Capitalize the name Optimizely
* Use a fully qualified URL for links from the README to avoid creating broken links on developer.fastly.com.

It would also help our users install the starter kit if you could flip this repo to be a template repo:
https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-template-repository

This will enable customers to use our cloud deploy tool to install your starter without using any local tooling:
https://deploy.edgecompute.app/optimizely/fastly-compute-starter-kit